### PR TITLE
Allow leading changelog entry space

### DIFF
--- a/__tests__/changelog_entries.test.ts
+++ b/__tests__/changelog_entries.test.ts
@@ -9,15 +9,47 @@ test('Extract nothing from markdown', async () => {
     expect(extractEntriesFromMarkdown(text)).toEqual(expectedOutput)
 })
 
+test('Extract changelog entries with leading spaces', async () => {
+    const txtWithLeadingSpace = `## Changelog
+### Changed
+- [TEST-123](https://www.vendic.nl/) Some change
+ - [TEST-123](https://www.vendic.nl/) Some change 2
+
+### Removed
+ - [TEST-123](https://www.vendic.nl/) Removal of something`
+
+
+    const expectedOutput : ChangelogEntry[] = [
+        {
+            text: '[TEST-123](https://www.vendic.nl/) Some change',
+            type: 'changed'
+        },
+        {
+            text: '[TEST-123](https://www.vendic.nl/) Some change 2',
+            type: 'changed'
+        },
+        {
+            text: '[TEST-123](https://www.vendic.nl/) Removal of something',
+            type: 'removed'
+        }
+    ]
+
+    expect(extractEntriesFromMarkdown(txtWithLeadingSpace)).toEqual(expectedOutput)
+})
+
 
 test('Extract single changelog entries fetched via the Github API', async () => {
-    const txt = `## Changelog\\r\\n### Changed\\r\\n- [Hello](World) Hello world`
+    const txt = `## Changelog\\r\\n### Changed\\r\\n- [Hello](World) Hello world\\r\\n- [Hello](World) Hello world\\r\\n`
 
     const expectedOutput : ChangelogEntry[] = [
         {
             text: '[Hello](World) Hello world',
             type: 'changed'
-        }
+        },
+        {
+            text: '[Hello](World) Hello world',
+            type: 'changed'
+        },
     ]
 
     expect(extractEntriesFromMarkdown(txt)).toEqual(expectedOutput)

--- a/dist/index.js
+++ b/dist/index.js
@@ -15077,17 +15077,18 @@ function extractEntriesFromMarkdown(markdown) {
         core.debug(`Value: ${themeContent}`);
         // Split the content based on newlines, then check if we are dealing with a list.
         themeContent
-            // Replace \r\n with \n
-            .replace('\\r\\n', '\n')
+            // Replace all "\r\n" with \n
+            .replace(/\\r\\n/g, '\n')
             // After several tests I found out that this regex is the most reliable
             // It splits on both \r\n and \n. The Github PR body that I tested contained \r\n line breaks
             .split(/(\r\n|\n)/)
             .filter((line) => {
-            return /^-\s{1}.*$/.test(line);
+            // See https://regex101.com/r/4XYvpR/1
+            return /^\s?-\s.*$/.test(line);
         })
             .forEach((filteredLine) => {
             changeLogEntries.push({
-                text: filteredLine.replace(/(^-\s|\\r\\n)/g, ''),
+                text: filteredLine.trim().replace(/(^-\s|\\r\\n)/g, ''),
                 type: section.toLowerCase()
             });
         });

--- a/src/changelog_entries.ts
+++ b/src/changelog_entries.ts
@@ -51,17 +51,18 @@ export function extractEntriesFromMarkdown(markdown : string) : ChangelogEntry[]
 
         // Split the content based on newlines, then check if we are dealing with a list.
          themeContent
-             // Replace \r\n with \n
-             .replace('\\r\\n', '\n')
+             // Replace all "\r\n" with \n
+             .replace(/\\r\\n/g, '\n')
              // After several tests I found out that this regex is the most reliable
              // It splits on both \r\n and \n. The Github PR body that I tested contained \r\n line breaks
             .split(/(\r\n|\n)/)
             .filter((line) => {
-                return /^-\s{1}.*$/.test(line)
+                // See https://regex101.com/r/4XYvpR/1
+                return /^\s?-\s.*$/.test(line)
             })
             .forEach((filteredLine)  => {
                 changeLogEntries.push({
-                    text: filteredLine.replace(/(^-\s|\\r\\n)/g, ''),
+                    text: filteredLine.trim().replace(/(^-\s|\\r\\n)/g, ''),
                     type: section.toLowerCase()
                 })
             })


### PR DESCRIPTION
Example of changelog entries with leading spaces:
```
## Changelog
### Changed
- [TEST-123](https://www.vendic.nl/) Some change
 - [TEST-123](https://www.vendic.nl/) Some change 2

### Removed
 - [TEST-123](https://www.vendic.nl/) Removal of something`
 ```
